### PR TITLE
Add config and script to build raspberry pi Image on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2.1
+jobs:
+  build:
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - checkout
+      - run:
+          name: "Building Raspberry Pi Image"
+          command: |
+              sudo apt-get install -y -q apt-utils
+              sudo apt install -y -q qemu
+              sudo modprobe binfmt-misc
+              ./run-build-docker.sh
+              ls ./deploy
+              cp ./deploy/Fomu-Dev-*.zip Fomu-Dev-latest.zip
+
+      - store_artifacts:
+          path: Fomu-Dev-latest.zip
+          destination: Fomu-Dev

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Fomu pi-gen
 
+Build Status : [![CircleCI](https://circleci.com/gh/whatnick/fomu-pi-gen.svg?style=svg)](https://circleci.com/gh/whatnick/fomu-pi-gen)
+
 _Fork of pi-gen used to create the Fomu development image_
 
 For more information, including how to customize this build, see [the original pi-gen repository](https://github.com/RPi-Distro/pi-gen/).

--- a/export-image/prerun.sh
+++ b/export-image/prerun.sh
@@ -55,15 +55,19 @@ echo "/:     offset $ROOT_OFFSET, length $ROOT_LENGTH"
 
 ROOT_FEATURES="^huge_file"
 for FEATURE in metadata_csum 64bit; do
+        echo "Doing $FEATURE"
 	if grep -q "$FEATURE" /etc/mke2fs.conf; then
 	    ROOT_FEATURES="^$FEATURE,$ROOT_FEATURES"
 	fi
 done
+echo "Making Boot FS"
 mkdosfs -n boot -F 32 -v "$BOOT_DEV" > /dev/null
 mkfs.ext4 -L rootfs -O "$ROOT_FEATURES" "$ROOT_DEV" > /dev/null
 
+echo "Making Root FS"
 mount -v "$ROOT_DEV" "${ROOTFS_DIR}" -t ext4
 mkdir -p "${ROOTFS_DIR}/boot"
 mount -v "$BOOT_DEV" "${ROOTFS_DIR}/boot" -t vfat
 
+echo "Performing RSync"
 rsync -aHAXx --exclude var/cache/apt/archives "${EXPORT_ROOTFS_DIR}/" "${ROOTFS_DIR}/" || true

--- a/export-noobs/prerun.sh
+++ b/export-noobs/prerun.sh
@@ -33,8 +33,11 @@ mount "$BOOT_DEV" "${STAGE_WORK_DIR}/rootfs/boot"
 
 ln -sv "/lib/systemd/system/apply_noobs_os_config.service" "$ROOTFS_DIR/etc/systemd/system/multi-user.target.wants/apply_noobs_os_config.service"
 
-bsdtar --numeric-owner --format gnutar --use-compress-program pxz -C "${STAGE_WORK_DIR}/rootfs/boot" -cpf "${NOOBS_DIR}/boot.tar.xz" .
+echo "Tarring Boot - This may take a while"
+bsdtar -v --numeric-owner --format gnutar --use-compress-program pxz -C "${STAGE_WORK_DIR}/rootfs/boot" -cpf "${NOOBS_DIR}/boot.tar.xz" .
 umount "${STAGE_WORK_DIR}/rootfs/boot"
-bsdtar --numeric-owner --format gnutar --use-compress-program pxz -C "${STAGE_WORK_DIR}/rootfs" --one-file-system -cpf "${NOOBS_DIR}/root.tar.xz" .
+
+echo "Tarring Root - This may take even longer"
+bsdtar -v --numeric-owner --format gnutar --use-compress-program pxz -C "${STAGE_WORK_DIR}/rootfs" --one-file-system -cpf "${NOOBS_DIR}/root.tar.xz" .
 
 unmount_image "${IMG_FILE}"

--- a/run-build-docker.sh
+++ b/run-build-docker.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 extra_config="config"
 git checkout config


### PR DESCRIPTION
Working circleci script to build the Raspbian Image Artifact on every commit. Useful for users without Linux/Docker setup to get a quick start on flashing Fomu's and a raspberry pi Fomu toolchain.

![image](https://user-images.githubusercontent.com/491396/62493062-83678600-b813-11e9-9b41-8b8f334e1e4a.png)
